### PR TITLE
feat: scaffold analytics platform with core services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Nestjs specific
-/dist
+dist
 node_modules/
 /build
 /tmp

--- a/analytics-platform/.prettierrc
+++ b/analytics-platform/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/analytics-platform/README.md
+++ b/analytics-platform/README.md
@@ -1,0 +1,98 @@
+<p align="center">
+  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
+</p>
+
+[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
+[circleci-url]: https://circleci.com/gh/nestjs/nest
+
+  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
+    <p align="center">
+<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
+<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
+<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
+<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
+<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
+<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
+<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
+  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
+    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
+  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
+</p>
+  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
+  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+
+## Description
+
+[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+
+## Project setup
+
+```bash
+$ npm install
+```
+
+## Compile and run the project
+
+```bash
+# development
+$ npm run start
+
+# watch mode
+$ npm run start:dev
+
+# production mode
+$ npm run start:prod
+```
+
+## Run tests
+
+```bash
+# unit tests
+$ npm run test
+
+# e2e tests
+$ npm run test:e2e
+
+# test coverage
+$ npm run test:cov
+```
+
+## Deployment
+
+When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
+
+If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
+
+```bash
+$ npm install -g @nestjs/mau
+$ mau deploy
+```
+
+With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
+
+## Resources
+
+Check out a few resources that may come in handy when working with NestJS:
+
+- Visit the [NestJS Documentation](https://docs.nestjs.com) to learn more about the framework.
+- For questions and support, please visit our [Discord channel](https://discord.gg/G7Qnnhy).
+- To dive deeper and get more hands-on experience, check out our official video [courses](https://courses.nestjs.com/).
+- Deploy your application to AWS with the help of [NestJS Mau](https://mau.nestjs.com) in just a few clicks.
+- Visualize your application graph and interact with the NestJS application in real-time using [NestJS Devtools](https://devtools.nestjs.com).
+- Need help with your project (part-time to full-time)? Check out our official [enterprise support](https://enterprise.nestjs.com).
+- To stay in the loop and get updates, follow us on [X](https://x.com/nestframework) and [LinkedIn](https://linkedin.com/company/nestjs).
+- Looking for a job, or have a job to offer? Check out our official [Jobs board](https://jobs.nestjs.com).
+
+## Support
+
+Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
+
+## Stay in touch
+
+- Author - [Kamil Myśliwiec](https://twitter.com/kammysliwiec)
+- Website - [https://nestjs.com](https://nestjs.com/)
+- Twitter - [@nestframework](https://twitter.com/nestframework)
+
+## License
+
+Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).

--- a/analytics-platform/apps/analytics-platform/src/app.controller.spec.ts
+++ b/analytics-platform/apps/analytics-platform/src/app.controller.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+describe('AppController', () => {
+  let appController: AppController;
+
+  beforeEach(async () => {
+    const app: TestingModule = await Test.createTestingModule({
+      controllers: [AppController],
+      providers: [AppService],
+    }).compile();
+
+    appController = app.get<AppController>(AppController);
+  });
+
+  describe('root', () => {
+    it('should return "Hello World!"', () => {
+      expect(appController.getHello()).toBe('Hello World!');
+    });
+  });
+});

--- a/analytics-platform/apps/analytics-platform/src/app.controller.ts
+++ b/analytics-platform/apps/analytics-platform/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+}

--- a/analytics-platform/apps/analytics-platform/src/app.module.ts
+++ b/analytics-platform/apps/analytics-platform/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+@Module({
+  imports: [],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/analytics-platform/apps/analytics-platform/src/app.service.ts
+++ b/analytics-platform/apps/analytics-platform/src/app.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHello(): string {
+    return 'Hello World!';
+  }
+}

--- a/analytics-platform/apps/analytics-platform/src/main.ts
+++ b/analytics-platform/apps/analytics-platform/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(process.env.PORT ?? 3000);
+}
+bootstrap();

--- a/analytics-platform/apps/analytics-platform/test/app.e2e-spec.ts
+++ b/analytics-platform/apps/analytics-platform/test/app.e2e-spec.ts
@@ -1,0 +1,25 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from './../src/app.module';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('/ (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect('Hello World!');
+  });
+});

--- a/analytics-platform/apps/analytics-platform/test/jest-e2e.json
+++ b/analytics-platform/apps/analytics-platform/test/jest-e2e.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}

--- a/analytics-platform/apps/analytics-platform/tsconfig.app.json
+++ b/analytics-platform/apps/analytics-platform/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "outDir": "../../dist/apps/analytics-platform"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/analytics-platform/apps/api-gateway/src/api-gateway.controller.spec.ts
+++ b/analytics-platform/apps/api-gateway/src/api-gateway.controller.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ApiGatewayController } from './api-gateway.controller';
+import { ApiGatewayService } from './api-gateway.service';
+
+describe('ApiGatewayController', () => {
+  let apiGatewayController: ApiGatewayController;
+
+  beforeEach(async () => {
+    const app: TestingModule = await Test.createTestingModule({
+      controllers: [ApiGatewayController],
+      providers: [ApiGatewayService],
+    }).compile();
+
+    apiGatewayController = app.get<ApiGatewayController>(ApiGatewayController);
+  });
+
+  describe('root', () => {
+    it('should return "Hello World!"', () => {
+      expect(apiGatewayController.getHello()).toBe('Hello World!');
+    });
+  });
+});

--- a/analytics-platform/apps/api-gateway/src/api-gateway.controller.ts
+++ b/analytics-platform/apps/api-gateway/src/api-gateway.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiGatewayService } from './api-gateway.service';
+
+@Controller()
+export class ApiGatewayController {
+  constructor(private readonly apiGatewayService: ApiGatewayService) {}
+
+  @Get()
+  getHello(): string {
+    return this.apiGatewayService.getHello();
+  }
+}

--- a/analytics-platform/apps/api-gateway/src/api-gateway.module.ts
+++ b/analytics-platform/apps/api-gateway/src/api-gateway.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ApiGatewayController } from './api-gateway.controller';
+import { ApiGatewayService } from './api-gateway.service';
+
+@Module({
+  imports: [],
+  controllers: [ApiGatewayController],
+  providers: [ApiGatewayService],
+})
+export class ApiGatewayModule {}

--- a/analytics-platform/apps/api-gateway/src/api-gateway.service.ts
+++ b/analytics-platform/apps/api-gateway/src/api-gateway.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ApiGatewayService {
+  getHello(): string {
+    return 'Hello World!';
+  }
+}

--- a/analytics-platform/apps/api-gateway/src/main.ts
+++ b/analytics-platform/apps/api-gateway/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { ApiGatewayModule } from './api-gateway.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(ApiGatewayModule);
+  await app.listen(process.env.port ?? 3000);
+}
+bootstrap();

--- a/analytics-platform/apps/api-gateway/test/app.e2e-spec.ts
+++ b/analytics-platform/apps/api-gateway/test/app.e2e-spec.ts
@@ -1,0 +1,24 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { ApiGatewayModule } from './../src/api-gateway.module';
+
+describe('ApiGatewayController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [ApiGatewayModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('/ (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect('Hello World!');
+  });
+});

--- a/analytics-platform/apps/api-gateway/test/jest-e2e.json
+++ b/analytics-platform/apps/api-gateway/test/jest-e2e.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}

--- a/analytics-platform/apps/api-gateway/tsconfig.app.json
+++ b/analytics-platform/apps/api-gateway/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "outDir": "../../dist/apps/api-gateway"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/analytics-platform/apps/event-processor/src/event-processor.controller.spec.ts
+++ b/analytics-platform/apps/event-processor/src/event-processor.controller.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventProcessorController } from './event-processor.controller';
+import { EventProcessorService } from './event-processor.service';
+
+describe('EventProcessorController', () => {
+  let eventProcessorController: EventProcessorController;
+
+  beforeEach(async () => {
+    const app: TestingModule = await Test.createTestingModule({
+      controllers: [EventProcessorController],
+      providers: [EventProcessorService],
+    }).compile();
+
+    eventProcessorController = app.get<EventProcessorController>(EventProcessorController);
+  });
+
+  describe('root', () => {
+    it('should return "Hello World!"', () => {
+      expect(eventProcessorController.getHello()).toBe('Hello World!');
+    });
+  });
+});

--- a/analytics-platform/apps/event-processor/src/event-processor.controller.ts
+++ b/analytics-platform/apps/event-processor/src/event-processor.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { EventProcessorService } from './event-processor.service';
+
+@Controller()
+export class EventProcessorController {
+  constructor(private readonly eventProcessorService: EventProcessorService) {}
+
+  @Get()
+  getHello(): string {
+    return this.eventProcessorService.getHello();
+  }
+}

--- a/analytics-platform/apps/event-processor/src/event-processor.module.ts
+++ b/analytics-platform/apps/event-processor/src/event-processor.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { EventProcessorController } from './event-processor.controller';
+import { EventProcessorService } from './event-processor.service';
+
+@Module({
+  imports: [],
+  controllers: [EventProcessorController],
+  providers: [EventProcessorService],
+})
+export class EventProcessorModule {}

--- a/analytics-platform/apps/event-processor/src/event-processor.service.ts
+++ b/analytics-platform/apps/event-processor/src/event-processor.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class EventProcessorService {
+  getHello(): string {
+    return 'Hello World!';
+  }
+}

--- a/analytics-platform/apps/event-processor/src/main.ts
+++ b/analytics-platform/apps/event-processor/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { EventProcessorModule } from './event-processor.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(EventProcessorModule);
+  await app.listen(process.env.port ?? 3000);
+}
+bootstrap();

--- a/analytics-platform/apps/event-processor/test/app.e2e-spec.ts
+++ b/analytics-platform/apps/event-processor/test/app.e2e-spec.ts
@@ -1,0 +1,24 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { EventProcessorModule } from './../src/event-processor.module';
+
+describe('EventProcessorController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [EventProcessorModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('/ (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect('Hello World!');
+  });
+});

--- a/analytics-platform/apps/event-processor/test/jest-e2e.json
+++ b/analytics-platform/apps/event-processor/test/jest-e2e.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}

--- a/analytics-platform/apps/event-processor/tsconfig.app.json
+++ b/analytics-platform/apps/event-processor/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "outDir": "../../dist/apps/event-processor"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/analytics-platform/eslint.config.mjs
+++ b/analytics-platform/eslint.config.mjs
@@ -1,0 +1,34 @@
+// @ts-check
+import eslint from '@eslint/js';
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: ['eslint.config.mjs'],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  eslintPluginPrettierRecommended,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+      },
+      sourceType: 'commonjs',
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-floating-promises': 'warn',
+      '@typescript-eslint/no-unsafe-argument': 'warn'
+    },
+  },
+);

--- a/analytics-platform/libs/shared/src/index.ts
+++ b/analytics-platform/libs/shared/src/index.ts
@@ -1,0 +1,2 @@
+export * from './shared.module';
+export * from './shared.service';

--- a/analytics-platform/libs/shared/src/shared.module.ts
+++ b/analytics-platform/libs/shared/src/shared.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { SharedService } from './shared.service';
+
+@Module({
+  providers: [SharedService],
+  exports: [SharedService],
+})
+export class SharedModule {}

--- a/analytics-platform/libs/shared/src/shared.service.spec.ts
+++ b/analytics-platform/libs/shared/src/shared.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SharedService } from './shared.service';
+
+describe('SharedService', () => {
+  let service: SharedService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SharedService],
+    }).compile();
+
+    service = module.get<SharedService>(SharedService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/analytics-platform/libs/shared/src/shared.service.ts
+++ b/analytics-platform/libs/shared/src/shared.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SharedService {}

--- a/analytics-platform/libs/shared/tsconfig.lib.json
+++ b/analytics-platform/libs/shared/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "../../dist/libs/shared"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/analytics-platform/nest-cli.json
+++ b/analytics-platform/nest-cli.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "apps/analytics-platform/src",
+  "compilerOptions": {
+    "deleteOutDir": true,
+    "webpack": true,
+    "tsConfigPath": "apps/analytics-platform/tsconfig.app.json"
+  },
+  "monorepo": true,
+  "root": "apps/analytics-platform",
+  "projects": {
+    "analytics-platform": {
+      "type": "application",
+      "root": "apps/analytics-platform",
+      "entryFile": "main",
+      "sourceRoot": "apps/analytics-platform/src",
+      "compilerOptions": {
+        "tsConfigPath": "apps/analytics-platform/tsconfig.app.json"
+      }
+    },
+    "api-gateway": {
+      "type": "application",
+      "root": "apps/api-gateway",
+      "entryFile": "main",
+      "sourceRoot": "apps/api-gateway/src",
+      "compilerOptions": {
+        "tsConfigPath": "apps/api-gateway/tsconfig.app.json"
+      }
+    },
+    "event-processor": {
+      "type": "application",
+      "root": "apps/event-processor",
+      "entryFile": "main",
+      "sourceRoot": "apps/event-processor/src",
+      "compilerOptions": {
+        "tsConfigPath": "apps/event-processor/tsconfig.app.json"
+      }
+    },
+    "shared": {
+      "type": "library",
+      "root": "libs/shared",
+      "entryFile": "index",
+      "sourceRoot": "libs/shared/src",
+      "compilerOptions": {
+        "tsConfigPath": "libs/shared/tsconfig.lib.json"
+      }
+    }
+  }
+}

--- a/analytics-platform/package.json
+++ b/analytics-platform/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "analytics-platform",
+  "version": "0.0.1",
+  "description": "",
+  "author": "",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "build": "nest build",
+    "format": "prettier --write \"apps/**/*.ts\" \"libs/**/*.ts\"",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:debug": "nest start --debug --watch",
+    "start:prod": "node dist/apps/analytics-platform/main",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:e2e": "jest --config ./apps/analytics-platform/test/jest-e2e.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^11.0.1",
+    "@nestjs/core": "^11.0.1",
+    "@nestjs/platform-express": "^11.0.1",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.2.0",
+    "@eslint/js": "^9.18.0",
+    "@nestjs/cli": "^11.0.0",
+    "@nestjs/schematics": "^11.0.0",
+    "@nestjs/testing": "^11.0.1",
+    "@types/express": "^5.0.0",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^22.10.7",
+    "@types/supertest": "^6.0.2",
+    "eslint": "^9.18.0",
+    "eslint-config-prettier": "^10.0.1",
+    "eslint-plugin-prettier": "^5.2.2",
+    "globals": "^16.0.0",
+    "jest": "^30.0.0",
+    "prettier": "^3.4.2",
+    "source-map-support": "^0.5.21",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.2.5",
+    "ts-loader": "^9.5.2",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.20.0"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": ".",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "./coverage",
+    "testEnvironment": "node",
+    "roots": [
+      "<rootDir>/apps/",
+      "<rootDir>/libs/"
+    ],
+    "moduleNameMapper": {
+      "^@app/shared(|/.*)$": "<rootDir>/libs/shared/src/$1",
+      "^@app/api-gateway/(.*)$": "<rootDir>/apps/api-gateway/src/$1",
+      "^@app/event-processor/(.*)$": "<rootDir>/apps/event-processor/src/$1"
+    }
+  }
+}

--- a/analytics-platform/tsconfig.build.json
+++ b/analytics-platform/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/analytics-platform/tsconfig.json
+++ b/analytics-platform/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "resolvePackageJsonExports": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2023",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": false,
+    "strictBindCallApply": false,
+    "noFallthroughCasesInSwitch": false,
+    "paths": {
+      "@app/shared": [
+        "libs/shared/src"
+      ],
+      "@app/shared/*": [
+        "libs/shared/src/*"
+      ],
+      "@app/api-gateway/*": [
+        "apps/api-gateway/src/*"
+      ],
+      "@app/event-processor/*": [
+        "apps/event-processor/src/*"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold analytics-platform monorepo using NestJS
- add api-gateway and event-processor apps with shared library
- configure path mapping and jest aliases

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68999c93f1688320815c13485a9045b3